### PR TITLE
[Fixed] Use of Damageable is not available in 1.8.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.5.3</version>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <id>shaded</id>
@@ -92,6 +92,7 @@
                                         <exclude>**/third_party/org/h2/**</exclude>
                                         <exclude>**/third_party/com/cryptomorin/**</exclude>
                                         <exclude>**/third_party/org/reactivestreams/**</exclude>
+                                        <exclude>**/third_party/io/papermc/lib/**</exclude>
                                     </excludes>
                                 </filter>
                             </filters>
@@ -131,7 +132,7 @@
         <dependency>
             <groupId>com.craftaro</groupId>
             <artifactId>CraftaroCore</artifactId>
-            <version>3.7.0-SNAPSHOT</version>
+            <version>3.8.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/craftaro/ultimaterepairing/gui/RepairGui.java
+++ b/src/main/java/com/craftaro/ultimaterepairing/gui/RepairGui.java
@@ -9,6 +9,7 @@ import com.craftaro.core.utils.TextUtils;
 import com.craftaro.ultimaterepairing.repair.RepairType;
 import com.craftaro.ultimaterepairing.settings.Settings;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
@@ -114,7 +115,10 @@ public class RepairGui extends Gui {
 
     private ItemStack[] getRepairableItems() {
         return Arrays.stream(player.getInventory().getContents())
-                .filter(item -> item != null && item.getDurability() > 0 && item.getMaxStackSize() == 1)
+                .filter(item -> item != null
+                        && item.getDurability() > 0
+                        && item.getMaxStackSize() == 1
+                        && item.getType() != Material.POTION)
                 .toArray(ItemStack[]::new);
     }
 

--- a/src/main/java/com/craftaro/ultimaterepairing/utils/Methods.java
+++ b/src/main/java/com/craftaro/ultimaterepairing/utils/Methods.java
@@ -1,6 +1,7 @@
 package com.craftaro.ultimaterepairing.utils;
 
 import com.craftaro.core.compatibility.CompatibleMaterial;
+import com.craftaro.core.compatibility.ServerVersion;
 import com.craftaro.third_party.com.cryptomorin.xseries.XMaterial;
 import com.craftaro.ultimaterepairing.UltimateRepairing;
 import com.craftaro.core.math.MathUtils;
@@ -36,21 +37,29 @@ public class Methods {
         String equationECO = Settings.ECONOMY_EQUATION.getString();
         String equationITEM = Settings.ITEM_EQUATION.getString();
 
-        equationXP = equationXP.replace("{MaxDurability}", Short.toString(item.getType().getMaxDurability()))
-                .replace("{Durability}", Integer.toString(item.getType().getMaxDurability() - ((Damageable)item.getItemMeta()).getDamage()))
-                .replace("{Damage}", Short.toString(item.getDurability()));
+        short maxDurability = item.getType().getMaxDurability();
+        short damage;
+        if (ServerVersion.isServerVersionBelow(ServerVersion.V1_11)) {
+            damage = item.getDurability();
+        } else {
+            damage = (short) ((Damageable) item.getItemMeta()).getDamage();
+        }
+
+        equationXP = equationXP.replace("{MaxDurability}", Short.toString(maxDurability))
+                .replace("{Durability}", Integer.toString(maxDurability - damage))
+                .replace("{Damage}", Short.toString(damage));
         int XPCost = (int) Math.round(MathUtils.eval(equationXP));
 
-        equationECO = equationECO.replace("{MaxDurability}", Short.toString(item.getType().getMaxDurability()))
-                .replace("{Durability}", Integer.toString(item.getType().getMaxDurability() - ((Damageable)item.getItemMeta()).getDamage()))
-                .replace("{Damage}", Short.toString(item.getDurability()))
+        equationECO = equationECO.replace("{MaxDurability}", Short.toString(maxDurability))
+                .replace("{Durability}", Integer.toString(maxDurability - damage))
+                .replace("{Damage}", Short.toString(damage))
                 .replace("{XPCost}", Integer.toString(XPCost));
 
         int ECOCost = (int) Math.round(MathUtils.eval(equationECO));
 
-        equationITEM = equationITEM.replace("{MaxDurability}", Short.toString(item.getType().getMaxDurability()))
-                .replace("{Durability}", Integer.toString(item.getType().getMaxDurability() - ((Damageable)item.getItemMeta()).getDamage()))
-                .replace("{Damage}", Short.toString(item.getDurability()))
+        equationITEM = equationITEM.replace("{MaxDurability}", Short.toString(maxDurability))
+                .replace("{Durability}", Integer.toString(maxDurability - damage))
+                .replace("{Damage}", Short.toString(damage))
                 .replace("{XPCost}", Integer.toString(XPCost));
 
         int ITEMCost = (int) Math.round(MathUtils.eval(equationITEM));


### PR DESCRIPTION
[Fixed] Ignore potions as a repairable item.